### PR TITLE
[AAI-123] Add AAI Engineering Standard

### DIFF
--- a/AAI_POLICY.md
+++ b/AAI_POLICY.md
@@ -1,0 +1,79 @@
+# AAI AI-Assisted Development Policy
+
+**Owner:** AAI Innovations GmbH
+**Status:** Mandatory
+**Version:** 1.0
+
+## Purpose
+This policy defines the mandatory requirements for AI-assisted software development within AAI.
+
+It supports:
+- ISO 9001
+- ISO/IEC 27001
+- ISO/IEC 42001
+- TISAX
+- Customer-specific contractual obligations
+
+## Scope
+This policy applies to all AAI repositories, employees, contractors and approved AI tools.
+
+## Mandatory Jira Traceability
+Every development activity shall reference an approved Jira Ticket or Epic.
+
+The Jira ID must appear in:
+- Branch name
+- Commit message
+- Pull Request
+
+Example:
+
+```text
+Branch: feature/AAI-123-add-validation
+Commit: AAI-123 Add validation
+PR: [AAI-123] Add validation
+```
+
+If no Jira ticket exists, one shall be created before development starts.
+
+## Human Responsibility
+AI suggestions must always be reviewed by a human developer.
+
+The developer remains responsible for correctness, security, testing, documentation, licensing and compliance.
+
+## Security
+Never expose passwords, API keys, secrets, customer confidential information or personal data to unauthorized AI services.
+
+## Development Requirements
+AI-generated code shall:
+- follow repository conventions
+- include tests where appropriate
+- update documentation
+- pass CI
+- avoid unnecessary dependencies
+
+## Pull Requests
+Every PR shall include:
+- Jira reference
+- implementation summary
+- testing performed
+- risks
+- AI usage declaration
+
+## Prohibited
+AI shall not be used to bypass reviews, fabricate evidence, commit secrets or merge without approval.
+
+## Traceability
+
+```text
+Requirement
+→ Jira
+→ Branch
+→ Commit
+→ Pull Request
+→ Review
+→ Test
+→ Release
+```
+
+## Exceptions
+Exceptions require documented management approval.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+<!-- AAI-ENGINEERING-STANDARD:START -->
+
+# AAI Engineering Standard for Claude Code
+
+This section is centrally managed by AAI.
+
+Claude shall follow:
+- AAI_POLICY.md
+- Repository-specific documentation
+- Repository-specific instructions outside this managed section
+
+## Jira Requirement
+
+Every change requires a Jira Ticket or Epic.
+
+Include the Jira ID in:
+- Branch
+- Commit
+- Pull Request
+
+## Development Rules
+
+Claude shall:
+- understand existing code before changing it
+- preserve repository-specific instructions
+- make the smallest appropriate change
+- update tests
+- update documentation
+- avoid unrelated modifications
+- never commit secrets
+
+## Human Review
+
+All Claude-generated changes require human review before merge.
+
+## Completion Checklist
+
+- [ ] Jira referenced
+- [ ] Tests updated
+- [ ] Documentation updated
+- [ ] No secrets committed
+- [ ] CI passes
+- [ ] Human review completed
+
+<!-- AAI-ENGINEERING-STANDARD:END -->


### PR DESCRIPTION
Adds the organization-wide AAI Engineering Standard.

This corrected rollout preserves existing repository-specific CLAUDE.md instructions and manages only the marked AAI section.

Jira: AAI-123