### PR TITLE
fix(example.ipynb): avoid UnboundLocalError when visualizer starts paused and docs: fix Truck percentage mismatch in example.ipynb

### DIFF
--- a/example.ipynb
+++ b/example.ipynb
@@ -87,6 +87,7 @@
     "            20)\n",
     "\n",
     "    vehicles = []\n",
+    "    light_states_visualizer = None  # avoid UnboundLocalError if visualizer starts paused\n",
     "\n",
     "    is_running = True\n",
     "    is_paused = False\n",
@@ -149,7 +150,10 @@
     "b) traffic_amount = 100 <br>\n",
     "c) spanwer_strategy = SPAWN_EVERYWHERE <br>\n",
     "d) ego_sensor_range = 200 <br>\n",
-    "e) roaduser_profiles = [[Car, 0.0], [Car, 0.85], [Bus, 0.03], [Truck, 0.01], [Motorcycle, 0.02]]<br>"
+    "e) roaduser_profiles = [[Car, 0.0], [Car, 0.85], [Bus, 0.03], [Truck, 0.01], [Motorcycle, 0.02]]<br>\n",
+    "#corrected\n",
+    "e) roaduser_profiles = [[Car, 0.0], [Car, 0.85], [Bus, 0.03], [Truck, 0.1], [Motorcycle, 0.02]] <br>\n",
+    "percentages must sum to 1.0. 0.85 + 0.03 + 0.01 + 0.02 = 0.91 (wrong). 0.85 + 0.03 + 0.1 + 0.02 = 1.0 (matches the notebook, which documents the same default and states explicitly that non-ego percentages must sum to 1.0).<br>"
    ]
   },
   {


### PR DESCRIPTION
light_states_visualizer was only assigned inside the `if not is_paused`
block. If is_paused() returns True on the first loop iteration, the
visualizer.update() call below references it before assignment.
Initialize it to None before the loop.


Default roaduser_profiles listed Truck at 0.01, which makes
 the non-ego percentages sum to 0.91 instead of 1.0. 
example.ipynb documents the same default at 0.1, which sums correctly.